### PR TITLE
Bugfix - Add 'transactions' into Products for Plaid Link

### DIFF
--- a/src/server/api/routers/plaid.ts
+++ b/src/server/api/routers/plaid.ts
@@ -67,7 +67,7 @@ export const plaidRouter = createTRPCRouter({
       }
       
       const endDate = new Date().toISOString().split('T')[0] ?? '';
-      const startDate = '2024-01-01';
+      const startDate = '2024-01-01'; // You might want to make this configurable
 
       // Get transaction count from Plaid
 

--- a/src/server/api/routers/plaid.ts
+++ b/src/server/api/routers/plaid.ts
@@ -67,19 +67,31 @@ export const plaidRouter = createTRPCRouter({
       }
       
       const endDate = new Date().toISOString().split('T')[0] ?? '';
+      const startDate = '2024-01-01';
 
       // Get transaction count from Plaid
-      const response = await plaidClient.transactionsGet({
-        access_token: accessToken.plaidAccessToken,
-        start_date: '2024-01-01', // You might want to make this configurable
-        end_date: endDate,
-        options: {
-          account_ids: [accountId],
-          count: 1, // We only need the count
-          offset: 0,
-        },
-      });
 
-      return response.data.total_transactions;
+      try {
+        const response = await plaidClient.transactionsGet({
+          access_token: accessToken.plaidAccessToken,
+          start_date: startDate,
+          end_date: endDate,
+          options: {
+            account_ids: [accountId],
+            count: 1,
+            offset: 0,
+          },
+        });
+
+        console.log("Plaid Transactions Response:", {
+          status: response.status,
+          data: response.data,
+        });
+        
+        return response.data.total_transactions;
+      } catch (error) {
+        console.error("Plaid API Error Response:", error.response?.data);
+        throw new Error("Failed to fetch transaction count. Please check the Plaid API logs.");
+      }
     }),
 });

--- a/src/server/api/routers/plaidLogin.ts
+++ b/src/server/api/routers/plaidLogin.ts
@@ -30,7 +30,7 @@ export const plaidLoginRouter = createTRPCRouter({
         client_user_id: ctx.session.user.id,
       },
       client_name: "AICFO",
-      products: [Products.Auth],
+      products: ['auth', 'transactions'] as Products[],
       country_codes: [CountryCode.Us],
       language: "en",
     };


### PR DESCRIPTION
**Major Changes**
- Add `transactions` into `products` request body for the `linkTokenCreate` API call to remove the `ADDITIONAL_CONSENT_REQUIRED` error.
- Add some error messaging to the `getTransactions` API

<img width="872" alt="Screen Shot 2024-12-13 at 7 01 47 PM" src="https://github.com/user-attachments/assets/80858539-18d9-4045-b281-da8214a759b4" />
