### PR TITLE
Fix bad migration file which referenced account

### DIFF
--- a/drizzle/0002_puzzling_phantom_reporter.sql
+++ b/drizzle/0002_puzzling_phantom_reporter.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS "test_t3_app_transactions" (
 	"plaid_account_id" text NOT NULL,
 	"transaction_id" varchar(255) NOT NULL,
 	"pending_transaction_id" varchar(255),
-	"account_id" varchar(255) NOT NULL,
+	"user_id" varchar(255) NOT NULL,
 	"amount" numeric(10, 2) NOT NULL,
 	"iso_currency_code" varchar(10),
 	"unofficial_currency_code" varchar(10),
@@ -25,10 +25,10 @@ CREATE TABLE IF NOT EXISTS "test_t3_app_transactions" (
 );
 --> statement-breakpoint
 DO $$ BEGIN
- ALTER TABLE "test_t3_app_transactions" ADD CONSTRAINT "test_t3_app_transactions_account_id_test_t3_app_account_user_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."test_t3_app_account"("user_id") ON DELETE no action ON UPDATE no action;
+ ALTER TABLE "test_t3_app_transactions" ADD CONSTRAINT "test_t3_app_transactions_user_id_test_t3_app_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."test_t3_app_user"("id") ON DELETE no action ON UPDATE no action;
 EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "transaction_account_id_idx" ON "test_t3_app_transactions" USING btree ("account_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transaction_user_id_idx" ON "test_t3_app_transactions" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "transaction_transaction_id_idx" ON "test_t3_app_transactions" USING btree ("transaction_id");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "75be178e-d6e6-436a-ab76-522a26d2357c",
+  "id": "79b4b442-1ed3-4d40-ac65-a31a936214d9",
   "prevId": "248426a1-5573-405f-8831-fe340886e963",
   "version": "7",
   "dialect": "postgresql",
@@ -301,8 +301,8 @@
           "primaryKey": false,
           "notNull": false
         },
-        "account_id": {
-          "name": "account_id",
+        "user_id": {
+          "name": "user_id",
           "type": "varchar(255)",
           "primaryKey": false,
           "notNull": true
@@ -414,11 +414,11 @@
         }
       },
       "indexes": {
-        "transaction_account_id_idx": {
-          "name": "transaction_account_id_idx",
+        "transaction_user_id_idx": {
+          "name": "transaction_user_id_idx",
           "columns": [
             {
-              "expression": "account_id",
+              "expression": "user_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -446,15 +446,15 @@
         }
       },
       "foreignKeys": {
-        "test_t3_app_transactions_account_id_test_t3_app_account_user_id_fk": {
-          "name": "test_t3_app_transactions_account_id_test_t3_app_account_user_id_fk",
+        "test_t3_app_transactions_user_id_test_t3_app_user_id_fk": {
+          "name": "test_t3_app_transactions_user_id_test_t3_app_user_id_fk",
           "tableFrom": "test_t3_app_transactions",
-          "tableTo": "test_t3_app_account",
+          "tableTo": "test_t3_app_user",
           "columnsFrom": [
-            "account_id"
+            "user_id"
           ],
           "columnsTo": [
-            "user_id"
+            "id"
           ],
           "onDelete": "no action",
           "onUpdate": "no action"

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -19,8 +19,8 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1734634534952,
-      "tag": "0002_cooing_dragon_man",
+      "when": 1734642572978,
+      "tag": "0002_puzzling_phantom_reporter",
       "breakpoints": true
     }
   ]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
+    "db:drop": "drizzle-kit drop",
     "dev": "next dev --turbo",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",

--- a/src/server/api/routers/plaid.ts
+++ b/src/server/api/routers/plaid.ts
@@ -87,7 +87,7 @@ export const plaidRouter = createTRPCRouter({
         transactionId: pTx.transaction_id,
         pendingTransactionId: pTx.pending_transaction_id ?? null,
 
-        accountId: ctx.session.user.id, // Ensure this matches an existing account
+        userId: ctx.session.user.id, // Ensure this matches an existing account
 
         amount: pTx.amount.toPrecision(10),
         isoCurrencyCode: pTx.iso_currency_code ?? null,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -150,9 +150,9 @@ export const transactions = createTable(
     pendingTransactionId: varchar("pending_transaction_id", { length: 255 }),
 
     // // Reference your internal account
-    accountId: varchar("account_id", { length: 255 })
+    userId: varchar("user_id", { length: 255 })
       .notNull()
-      .references(() => accounts.userId),
+      .references(() => users.id),
 
     // Financial details
     amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
@@ -182,12 +182,12 @@ export const transactions = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (transaction) => ({
-    accountIdIdx: index("transaction_account_id_idx").on(transaction.accountId),
+    userIdIdx: index("transaction_user_id_idx").on(transaction.userId),
     transactionIdIdx: index("transaction_transaction_id_idx").on(transaction.transactionId),
   })
 );
 
 export const transactionsRelations = relations(transactions, ({ one }) => ({
-  account: one(accounts, { fields: [transactions.accountId], references: [accounts.userId] })
+  user: one(users, { fields: [transactions.userId], references: [users.id] })
 }));
 


### PR DESCRIPTION
Changes:
- Reset migration file which adds account_id foreign key reference to transactions table
- Replace account_id with user_id

The problem here is that the accounts table represents different ways the user could log in, for example a Discord account or a Google account. So there's a many-to-one relationship from accounts to user. Users.id is then the unique identifier for a user, and should be referenced by the transactions table and elsewhere